### PR TITLE
Rudimentary Camera Mode Created

### DIFF
--- a/Unity_stuff/graph renderer unity project/Assets/Scenes/scanner_scene.unity
+++ b/Unity_stuff/graph renderer unity project/Assets/Scenes/scanner_scene.unity
@@ -2568,7 +2568,6 @@ MonoBehaviour:
   ChildDistanceConnectionsEffect: 5
   RepulsionRadius: 10
   TanhSoften: 0.15
-  ColorModeIDX: 0
   ColorMutationRate: 0.42
   SecondsPerPhysicsUpdate: 0
   FastestPhysicsUpdates: 0.1
@@ -2578,7 +2577,8 @@ MonoBehaviour:
   RotationSpeed: 3
   BoostValue: 3
   IsTypingUrl: 0
-  IsPuased: 0
+  IsPaused: 0
+  IsCameraOn: 0
 --- !u!114 &963194230
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2611,6 +2611,7 @@ MonoBehaviour:
   InitPositions: []
   vars: {fileID: 963194229}
   YouISystem: {fileID: 808878397}
+  YouIObject: {fileID: 808878392}
 --- !u!1 &976267864
 GameObject:
   m_ObjectHideFlags: 0

--- a/Unity_stuff/graph renderer unity project/Assets/scripts/CameraMounted/InputSystem.cs
+++ b/Unity_stuff/graph renderer unity project/Assets/scripts/CameraMounted/InputSystem.cs
@@ -8,6 +8,7 @@ public class InputSystem : MonoBehaviour
     public List<Vector3> InitPositions;
     public VarHolder vars;
     public UiSystem YouISystem;
+    public GameObject YouIObject;
 
     private float is_boosting = 1;
     private float totalXRotation = 0f;
@@ -126,6 +127,12 @@ public class InputSystem : MonoBehaviour
         else
         {
             Cursor.lockState = CursorLockMode.Locked;
+        }
+
+        if (Input.GetKeyDown(KeyCode.P))
+        {
+            vars.IsCameraOn = !vars.IsCameraOn;
+            YouIObject.SetActive(vars.IsCameraOn);
         }
     }
 }

--- a/Unity_stuff/graph renderer unity project/Assets/scripts/misc/UiSystem.cs
+++ b/Unity_stuff/graph renderer unity project/Assets/scripts/misc/UiSystem.cs
@@ -54,7 +54,7 @@ public class UiSystem : MonoBehaviour
     }
 
     private void Update()
-    {
+    { 
         throttle_red_shift = Color.Lerp(new Color(255f, 61f, 61f), new Color(255f, 255f, 255f), vars.SecondsPerPhysicsUpdate / vars.SlowestPhysicsUpdates);
 
         physics_update_rate_throttle.GetComponent<RawImage>().color = throttle_red_shift / 256;
@@ -73,7 +73,8 @@ public class UiSystem : MonoBehaviour
 
             ChangeText(locked_node_url_text, node.node_url, new Color(138f, 175f, 255f));
 
-            if (node.expanded) {
+            if (node.expanded)
+            {
                 ChangeText(locked_node_scanned_text, "SCANNED", new Color(54f, 255f, 97f));
 
                 if (node.is_cycle)
@@ -85,24 +86,34 @@ public class UiSystem : MonoBehaviour
                     ChangeText(locked_node_cycle_text, "NON CYCLICAL", new Color(138f, 175f, 255f));
                 }
             }
-            else {
+            else
+            {
                 string text;
-                if (node.scanning) {
-                    text = "SCANNING "+node.downloadProgress+"%";
-                } else {
-                    if (node.expanded) {
+                if (node.scanning)
+                {
+                    text = "SCANNING " + node.downloadProgress + "%";
+                }
+                else
+                {
+                    if (node.expanded)
+                    {
                         text = "SCANNED";
-                    } else {
-                        if (string.IsNullOrEmpty(node.scanError)) {
+                    }
+                    else
+                    {
+                        if (string.IsNullOrEmpty(node.scanError))
+                        {
                             text = "NOT SCANNED";
-                        } else {
-                            text = "ERROR - "+node.scanError;
+                        }
+                        else
+                        {
+                            text = "ERROR - " + node.scanError;
                         }
                     }
                 }
                 ChangeText(locked_node_scanned_text, text, new Color(255f, 79f, 79f));
                 ChangeText(locked_node_cycle_text, "UNKOWN - SCAN REQUIRED", new Color(255f, 79f, 79f));
-                
+
             }
         }
         else

--- a/Unity_stuff/graph renderer unity project/Assets/scripts/misc/VarHolder.cs
+++ b/Unity_stuff/graph renderer unity project/Assets/scripts/misc/VarHolder.cs
@@ -59,4 +59,8 @@ public class VarHolder : MonoBehaviour
     // to check if the player is currently paused
     [HideInInspector]
     public bool IsPaused;
+
+    // to check if camera mode is on
+    [HideInInspector]
+    public bool IsCameraOn;
 }


### PR DESCRIPTION
Currently, the camera mode disables the Canvas game object when active. This is similar to Minecraft F1 mode. I plan on adding a special camera mode UI, filters, and custom save locations.

I didn't find any bugs in my limited testing. It defintally needs more testing.

To enable the camera mode, use the hotkey: P

This feature was added in response to #33.
![image](https://github.com/marmust/internet-scanner/assets/60891047/c0dea96f-3393-4b29-bd64-19f4d7456d2f)
